### PR TITLE
Add php7.0-mbstring to Ubuntu packages

### DIFF
--- a/docs/Ubuntu/ubuntu-packages-1604
+++ b/docs/Ubuntu/ubuntu-packages-1604
@@ -61,6 +61,7 @@ php7.0-fpm
 php7.0-gd
 php7.0-intl
 php7.0-mcrypt
+php7.0-mbstring
 php7.0-mysql
 php7.0-sqlite3
 php7.0-xml


### PR DESCRIPTION
Package mbstring is needed for different mb_* functions, used through the gui